### PR TITLE
Use beforescriptexecute event to hook into script lifecycle

### DIFF
--- a/lib/thingamajig_browser.js
+++ b/lib/thingamajig_browser.js
@@ -1,228 +1,254 @@
-if (typeof thingamajig == 'undefined') {
-  var revaluate = require('revaluate');
+var revaluate = require('revaluate');
 
-  stop();
+(function() {
+  if ('onbeforescriptexecute' in document) {
+    return;
+  }
 
-  var xhr = new XMLHttpRequest();
-  xhr.open('GET', location.href);
-  xhr.onload = function(event) {
-    var html = xhr.responseText
-      .replace(/type=\"text\/javascript\"/g, '')
-      .replace(/<script/g, '<script type="live/javascript"');
+  window.stop();
 
-    document.write(html);
-    document.close();
+  var scripts = document.getElementsByTagName('script');
+  var skip = scripts.length;
+  document.open();
 
-    var scripts = document.scripts;
-    setTimeout(function next(index) {
-      var script = scripts[index];
-      if (script == null) {
-        return;
-      }
+  setTimeout(function () {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', location.href);
+    xhr.onload = function(event) {
+      document.write(xhr.responseText
+        .replace(/type=\"text\/javascript\"/g, 'data-beforescriptexecutetype')
+        .replace(/<script/g, '<script type="beforescriptexecute"')
+      );
+      document.close();
 
-      if (script.hasAttribute('src')) {
-        xhr = new XMLHttpRequest();
-        xhr.open('GET', script.getAttribute('src'));
-        xhr.onload = function() {
-          revaluate(xhr.responseText, script.getAttribute('src'), function(output) {
-            eval(output.code);
-          });
-
-          if(!script.hasAttribute('async')) {
-            setTimeout(next, 0, ++index);
-          }
-        };
-
-        if(script.hasAttribute('async')) {
-          setTimeout(next, 0, ++index);
+      var scripts = document.getElementsByTagName('script');
+      for (var i = 0; i < scripts.length; i++) {
+        var script = scripts[i];
+        if (script.getAttribute('type') != 'beforescriptexecute') {
+          continue;
         }
 
-        xhr.onerror = function() {};
-        xhr.send(null);
-      } else {
-        script.setAttribute('name', index);
+        if (script.hasAttribute('data-beforescriptexecutetype')) {
+          script.removeAttribute('data-beforescriptexecutetype');
+          script.setAttribute('type', 'text/javascript');
+        } else {
+          script.removeAttribute('type');
+        }
 
-        revaluate(script.innerText, script.getAttribute('name'), function(output) {
+        if (i < skip) {
+          continue;
+        }
+
+        var beforescriptexecute = document.createEvent('Event');
+        beforescriptexecute.initEvent('beforescriptexecute', true, true);
+        if (!script.dispatchEvent(beforescriptexecute)) {
+          continue;
+        }
+
+        var placeholder = document.createElement('span');
+        script.parentElement.replaceChild(placeholder, script);
+        placeholder.parentElement.replaceChild(script, placeholder);
+        
+        var afterscriptexecute = document.createEvent('Event');
+        afterscriptexecute.initEvent('afterscriptexecute', true, true);
+        script.dispatchEvent(afterscriptexecute);
+      }
+    };
+
+    xhr.send(null);
+  });
+}());
+
+document.addEventListener('beforescriptexecute', function(event) {
+  var script = event.target;
+  script.setAttribute('live', '');
+
+  if (script.hasAttribute('src')) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', script.getAttribute('src'), script.hasAttribute('async'));
+    xhr.onload = function() {
+      revaluate(xhr.responseText, script.getAttribute('src'), function(output) {
+        eval(output.code);
+      });
+    };
+
+    xhr.send(null);
+  } else {
+    script.setAttribute('name', Date.now().toString(36));
+    revaluate(script.innerText, script.getAttribute('name'), function(output) {
+      eval(output.code);
+    });
+  }
+
+  event.preventDefault();
+});
+
+setTimeout(function next(contents) {
+  var scripts = document.scripts;
+
+  for (var i = 0; i < scripts.length; i++) {
+    var script = scripts[i];
+
+    if (script.hasAttribute('src')) {
+      continue;
+    }
+
+    if (!script.hasAttribute('live')) {
+      continue;
+    }
+
+    var name = script.getAttribute('name');
+
+    if (script.textContent != contents[name]) {
+      var content = script.textContent;
+      if (contents[name]) {
+        revaluate(content, name, function(output) {
           eval(output.code);
         });
-
-        setTimeout(next, 0, ++index);
-      }
-    }, 0, 0);
-  };
-
-  xhr.onerror = function() {};
-  xhr.send(null);
-
-  setTimeout(function next(contents) {
-    var scripts = document.scripts;
-
-    for (var i = 0; i < scripts.length; i++) {
-      var script = scripts[i];
-
-      if (script.hasAttribute('src')) {
-        continue;
       }
 
-      if (script.getAttribute('type') != 'live/javascript') {
-        continue;
-      }
+      contents[name] = content;
+    }
+  }
 
-      var name = script.getAttribute('name');
+  setTimeout(next, 250, contents);
+}, 0, {});
 
-      if (script.textContent != contents[name]) {
-        var content = script.textContent;
-        if (contents[name]) {
-          revaluate(content, name, function(output) {
-            eval(output.code);
-          });
+setTimeout(function next(headers, pending) {
+  var urls = [];
+
+  if (!pending[location.href]) {
+    urls.push(location.href);
+  }
+
+  var scripts = document.scripts;
+  for (var i = 0; i < scripts.length; i++) {
+    var script = scripts[i];
+
+    if (!script.hasAttribute('src')) {
+      continue;
+    }
+
+    if (pending[script.getAttribute('src')]) {
+      continue;
+    }
+
+    urls.push(script.getAttribute('src'));
+  }
+
+  var links = document.getElementsByTagName('link');
+  for (var i = 0; i < links.length; i++) {
+    var link = links[i];
+
+    if (!link.hasAttribute('href')) {
+      continue;
+    }
+
+    urls.push(link.getAttribute('href'));
+  }
+
+  for (var i = 0; i < urls.length; i++) {
+    var url = urls[i];
+    var xhr = new XMLHttpRequest();
+
+
+    setTimeout(function(url, xhr) {
+      xhr.open('HEAD', url, true);
+
+      xhr.onload = function(event) {
+        var modified = false;
+        if (headers[url]) {
+          var names = [ 'Last-Modified' ];
+
+          for (var i = 0; i < names.length; i++) {
+            var name = names[i];
+            var prev = headers[url][name];
+            var curr = xhr.getResponseHeader(name);
+
+            if (prev != curr) {
+              modified = true;
+              break;
+            }
+          }
+        } else {
+          headers[url] = {};
         }
 
-        contents[name] = content;
-      }
-    }
+        var head = xhr.getAllResponseHeaders();
+        var entries = head.split('\u000d\u000a');
 
-    setTimeout(next, 250, contents);
-  }, 0, {});
+        for (var i = 0; i < entries.length; i++) {
+          var entry = entries[i];
 
-  setTimeout(function next(headers, pending) {
-    var urls = [];
+          var index = entry.indexOf('\u003a\u0020');
+          if (index > 0) {
+            var name = entry.substring(0, index);
+            var value = entry.substring(index + 2);
+            headers[url][name] = value;
+          }
+        }
 
-    if (!pending[location.href]) {
-      urls.push(location.href);
-    }
+        if (modified) {
+          var type = xhr.getResponseHeader('Content-Type').split(';')[0]
 
-    var scripts = document.scripts;
-    for (var i = 0; i < scripts.length; i++) {
-      var script = scripts[i];
+          switch (type) {
+            case 'text/css':
+              var links = document.getElementsByTagName('link');
+              for (var i = 0; i < links.length; i++) {
+                var link = links[i];
 
-      if (!script.hasAttribute('src')) {
-        continue;
-      }
+                if (url == link.getAttribute('href')) {
+                  var clone = document.createElement('link');
+                  clone.setAttribute('type', 'text/css');
+                  clone.setAttribute('rel', 'stylesheet');
+                  clone.setAttribute('href', url);
 
-      if (pending[script.getAttribute('src')]) {
-        continue;
-      }
-
-      urls.push(script.getAttribute('src'));
-    }
-
-    var links = document.getElementsByTagName('link');
-    for (var i = 0; i < links.length; i++) {
-      var link = links[i];
-
-      if (!link.hasAttribute('href')) {
-        continue;
-      }
-
-      urls.push(link.getAttribute('href'));
-    }
-
-    for (var i = 0; i < urls.length; i++) {
-      var url = urls[i];
-      var xhr = new XMLHttpRequest();
-
-
-      setTimeout(function(url, xhr) {
-        xhr.open('HEAD', url, true);
-
-        xhr.onload = function(event) {
-          var modified = false;
-          if (headers[url]) {
-            var names = [ 'Last-Modified' ];
-
-            for (var i = 0; i < names.length; i++) {
-              var name = names[i];
-              var prev = headers[url][name];
-              var curr = xhr.getResponseHeader(name);
-
-              if (prev != curr) {
-                modified = true;
-                break;
+                  link.parentElement.replaceChild(clone, link);
+                }
               }
-            }
-          } else {
-            headers[url] = {};
-          }
+              break;
+            case 'text/html':
+              location.reload();
+              break;
 
-          var head = xhr.getAllResponseHeaders();
-          var entries = head.split('\u000d\u000a');
+            case 'text/javascript':
+            case 'application/javascript':
+            case 'application/x-javascript':
+              var scripts = document.getElementsByTagName('script');
+              for (var i = 0; i < scripts.length; i++) {
+                var script = scripts[i];
 
-          for (var i = 0; i < entries.length; i++) {
-            var entry = entries[i];
+                if (url == script.getAttribute('src')) {
+                  if (script.hasAttribute('live')) {
+                    xhr.open('GET', url, true);
+                    xhr.onload = function() {
+                      var content = xhr.responseText;
 
-            var index = entry.indexOf('\u003a\u0020');
-            if (index > 0) {
-              var name = entry.substring(0, index);
-              var value = entry.substring(index + 2);
-              headers[url][name] = value;
-            }
-          }
+                      revaluate(content, url, function(output) {
+                        eval(output.code);
+                      });
 
-          if (modified) {
-            var type = xhr.getResponseHeader('Content-Type').split(';')[0]
+                      delete pending[url];
+                    };
 
-            switch (type) {
-              case 'text/css':
-                var links = document.getElementsByTagName('link');
-                for (var i = 0; i < links.length; i++) {
-                  var link = links[i];
-
-                  if (url == link.getAttribute('href')) {
-                    var clone = document.createElement('link');
-                    clone.setAttribute('type', 'text/css');
-                    clone.setAttribute('rel', 'stylesheet');
-                    clone.setAttribute('href', url);
-
-                    link.parentElement.replaceChild(clone, link);
+                    xhr.send(null);
+                  } else {
+                    location.reload();
                   }
                 }
-                break;
-              case 'text/html':
-                location.reload();
-                break;
-
-              case 'text/javascript':
-              case 'application/javascript':
-              case 'application/x-javascript':
-                var scripts = document.getElementsByTagName('script');
-                for (var i = 0; i < scripts.length; i++) {
-                  var script = scripts[i];
-
-                  if (url == script.getAttribute('src')) {
-                    if (script.getAttribute('type') == 'live/javascript') {
-                      xhr.open('GET', url, true);
-                      xhr.onload = function() {
-                        var content = xhr.responseText;
-
-                        revaluate(content, url, function(output) {
-                          eval(output.code);
-                        });
-
-                        delete pending[url];
-                      };
-
-                      xhr.send(null);
-                    } else {
-                      location.reload();
-                    }
-                  }
-                }
-                break;
-            }
-          } else {
-            delete pending[url];
+              }
+              break;
           }
-        };
+        } else {
+          delete pending[url];
+        }
+      };
 
-        xhr.send(null);
-      }, 0, url, xhr);
+      xhr.send(null);
+    }, 0, url, xhr);
 
-      pending[url] = xhr;
-    }
+    pending[url] = xhr;
+  }
 
-    setTimeout(next, 250, headers, pending);
-  }, 0, {}, {});
-
-  thingamajig = true;
-}
+  setTimeout(next, 250, headers, pending);
+}, 0, {}, {});


### PR DESCRIPTION
This makes use of the  native`beforescriptexecute` event to prevent script loading, if it is not available it will be approximated by doing a full page stop and manual loading.

When merged, this will close #13.