### PR TITLE
Keep link elements when reloading stylesheets

### DIFF
--- a/lib/thingamajig_browser.js
+++ b/lib/thingamajig_browser.js
@@ -256,14 +256,12 @@ setTimeout(function next(headers, pending) {
               for (var i = 0; i < links.length; i++) {
                 var link = links[i];
 
-                if (url == link.getAttribute('href')) {
-                  var clone = document.createElement('link');
-                  clone.setAttribute('type', 'text/css');
-                  clone.setAttribute('rel', 'stylesheet');
-                  clone.setAttribute('href', url);
-
-                  link.parentElement.replaceChild(clone, link);
+                if (url != link.getAttribute('href')) {
+                  continue;
                 }
+
+                link.removeAttribute('href');
+                link.setAttribute('href', url);
               }
               break;
             case 'text/html':


### PR DESCRIPTION
Keeps the link elements when reloading stylesheets, just changing the href attribute instead of replacing the entire element with a clone.